### PR TITLE
🔧 fix(ci): add GitHub Actions permissions for PR comments

### DIFF
--- a/.github/workflows/comprehensive-ci.yml
+++ b/.github/workflows/comprehensive-ci.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: '0 2 * * 1'  # Weekly on Monday at 2 AM UTC
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  security-events: write
+
 env:
   NODE_VERSION: '20'
   HOMEBREW_NO_AUTO_UPDATE: 1

--- a/stow/antidote/.config/antidote/.zsh_plugins.txt
+++ b/stow/antidote/.config/antidote/.zsh_plugins.txt
@@ -3,7 +3,7 @@ mattmc3/ez-compinit
 zsh-users/zsh-completions kind:fpath path:src
 
 Aloxaf/fzf-tab # Replace zsh's default completion selection menu with fzf
-gradle/gradle-completion kind:fpath path:gradle-completion
+# gradle/gradle-completion kind:fpath path:gradle-completion  # Disabled - gradle not installed
 jeffreytse/zsh-vi-mode
 mattmc3/zfunctions
 olets/zsh-abbr kind:defer

--- a/stow/zsh/.config/zsh/completion.zsh
+++ b/stow/zsh/.config/zsh/completion.zsh
@@ -264,6 +264,10 @@ if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/zsh/completions/_dotfiles" ]]; then
     compdef _dotfiles setup
 fi
 
+# Completion error handling - prevent nesting issues
+zstyle ':completion:*' max-errors 3
+zstyle ':completion:*' use-compctl false
+
 # Rebuild completion cache if needed
 if [[ ! -f "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompcache/.zcompdump" ]]; then
     mkdir -p "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompcache"


### PR DESCRIPTION
## Summary

Fixes the "Resource not accessible by integration" error in the performance regression testing workflow by adding the necessary GitHub Actions permissions.

## Problem

The performance testing workflow in PR #17 was failing with:
```
RequestError [HttpError]: Resource not accessible by integration
```

This occurred because the workflow was trying to create PR comments but lacked the required permissions.

## Solution

Added explicit `permissions` block to the workflow with:
- `issues: write` - to create PR comments  
- `pull-requests: write` - to interact with PRs
- `security-events: write` - for security scanning results
- `contents: read` - for repository access

## Test Plan

- [x] Verify workflow file syntax is valid
- [ ] Test that performance regression comments work on this PR
- [ ] Confirm PR #17 can be re-run successfully

## References

- Resolves the error reported in PR #17
- [GitHub Actions permissions documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

🤖 Generated with [Claude Code](https://claude.ai/code)