### PR TITLE
fix(ci): correctly handle escape codes in performance analysis

### DIFF
--- a/.github/workflows/comprehensive-ci.yml
+++ b/.github/workflows/comprehensive-ci.yml
@@ -177,7 +177,7 @@ jobs:
       run: |
         if [ -f "bin/measure-shell-performance.sh" ]; then
           chmod +x bin/measure-shell-performance.sh
-          if ! gtimeout 120 ./bin/measure-shell-performance.sh 10 > ../baseline-performance.log; then
+          if ! gtimeout 120 ./bin/measure-shell-performance.sh --no-color 10 > ../baseline-performance.log; then
             echo "Performance script failed, skipping detailed analysis"
           fi
         fi
@@ -193,7 +193,7 @@ jobs:
       run: |
         if [ -f "bin/measure-shell-performance.sh" ]; then
           chmod +x bin/measure-shell-performance.sh
-          if ! gtimeout 120 ./bin/measure-shell-performance.sh 10 > ../pr-performance.log; then
+          if ! gtimeout 120 ./bin/measure-shell-performance.sh --no-color 10 > ../pr-performance.log; then
             echo "Performance script failed, skipping detailed analysis"
           fi
         fi

--- a/bin/measure-shell-performance.sh
+++ b/bin/measure-shell-performance.sh
@@ -4,12 +4,27 @@ set -euo pipefail
 # Shell Performance Measurement Script
 # Measures zsh startup time and provides optimization recommendations
 
+# Handle --no-color flag
+NO_COLOR=false
+if [[ "${1:-}" == "--no-color" ]]; then
+    NO_COLOR=true
+    shift
+fi
+
 # Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+if [[ "$NO_COLOR" = true ]]; then
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+else
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+fi
 
 # Configuration
 ITERATIONS=${1:-10}


### PR DESCRIPTION
This pull request addresses issue #54.

The performance analysis comment in pull requests was showing raw escape codes instead of colored text.

This has been fixed by:
- Adding a `--no-color` flag to the `measure-shell-performance.sh` script to disable color output.
- Using the `--no-color` flag in the `comprehensive-ci.yml` workflow when running the performance analysis.

This ensures that the output captured for the GitHub comment does not contain any escape codes.

Closes #54