### PR TITLE
🎉 feat(zsh): add git worktree workflow helpers

### DIFF
--- a/stow/git-worktree-workflow/bin/git-init-worktree
+++ b/stow/git-worktree-workflow/bin/git-init-worktree
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Usage: git-init-worktree <repo_url>
+REPO_URL=$1
+
+# Ensure the base directory exists
+if [ -z "$PROJECT_BASE" ]; then
+    echo "❌ Error: \$PROJECT_BASE is not set."
+    exit 1
+fi
+
+if [ -z "$REPO_URL" ]; then
+    echo "Usage: $0 <repo_url>"
+    exit 1
+fi
+
+# Extract project name from URL (handles both HTTPS and SSH formats)
+PROJECT_NAME=$(basename "$REPO_URL" .git)
+
+echo "🏠 Moving to Project base: $PROJECT_BASE"
+cd "$PROJECT_BASE" || exit
+
+echo "📂 Creating project directory: $PROJECT_NAME..."
+mkdir -p "$PROJECT_NAME" && cd "$PROJECT_NAME" || exit 1
+
+# 1. Clone Bare
+git clone --bare "$REPO_URL" .bare
+
+# 2. Setup Pointer
+echo "gitdir: ./.bare" > .git
+
+# 3. CRITICAL: Configure the refspec so 'fetch' brings in all remote branches
+# Without this, 'origin/branch' references won't exist locally!
+git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+
+echo "🔄 Initializing data..."
+git fetch origin
+
+# 4. Get Default Branch
+DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+DEFAULT_FOLDER="${DEFAULT_BRANCH//[\/\\]/_}"
+
+echo "🌳 Adding worktree for $DEFAULT_BRANCH..."
+git worktree add "$DEFAULT_FOLDER" "$DEFAULT_BRANCH"
+
+echo "✅ Ready! Project at: $(pwd)"

--- a/stow/git-worktree-workflow/git-worktree-helper.zsh
+++ b/stow/git-worktree-workflow/git-worktree-helper.zsh
@@ -1,0 +1,36 @@
+# vim: set ft=zsh:
+# shellcheck shell=bash
+# Git Worktree Helper Functions
+# Provides helper functions for managing git worktrees in bare-clone projects.
+
+function gwt-add() {
+    if [[ ! -d ".bare" ]]; then
+        echo "❌ Error: Not in a bare-worktree project root."
+        return 1
+    fi
+    
+    local BRANCH=$1
+    if [[ -z "$BRANCH" ]]; then
+        echo "Usage: gwt-add <branch-name>"
+        return 1
+    fi
+
+    # Sanitize folder name
+    local FOLDER_NAME="${BRANCH//[\/\\]/_}"
+
+    echo "🔍 Checking for branch: $BRANCH..."
+
+    # Check if branch exists locally or on remote
+    # ls-remote checks the server; rev-parse checks local cache
+    if git rev-parse --verify "$BRANCH" >/dev/null 2>&1 || \
+       git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+        
+        echo "🌿 Branch '$BRANCH' found. Tracking..."
+        # Fetch first to ensure the bare repo has the objects for this branch
+        git fetch origin "$BRANCH"
+        git worktree add "$FOLDER_NAME" "$BRANCH"
+    else
+        echo "✨ Branch '$BRANCH' not found. Creating new..."
+        git worktree add -b "$BRANCH" "$FOLDER_NAME"
+    fi
+}

--- a/stow/zsh/.config/zsh/environment.zsh
+++ b/stow/zsh/.config/zsh/environment.zsh
@@ -9,6 +9,7 @@ for file in "${ZDOTDIR:-$HOME/.config/zsh}/detect-env.zsh" \
             "${ZDOTDIR:-$HOME/.config/zsh}/terminal.zsh" \
             "${ZDOTDIR:-$HOME/.config/zsh}/plugins.zsh" \
             "${ZDOTDIR:-$HOME/.config/zsh}/git-ssh.zsh" \
+            "${ZDOTDIR:-$HOME/.config/zsh}/git-worktree-helper.zsh" \
             "${ZDOTDIR:-$HOME/.config/zsh}/utils.zsh"; do
     if [[ -f "$file" ]]; then
         source "$file"

--- a/stow/zsh/.config/zsh/git-worktree-helper.zsh
+++ b/stow/zsh/.config/zsh/git-worktree-helper.zsh
@@ -1,0 +1,1 @@
+../../../git-worktree-workflow/git-worktree-helper.zsh


### PR DESCRIPTION
## Summary

- Add `git-init-worktree` script to initialize new projects with bare clone worktree setup
- Add `gwt-add` zsh function for adding worktrees (handles both existing and new branches)
- Integrate helpers into zsh environment sourcing via symlink

## Features

**`git-init-worktree`**: Sets up a new project directory with:
- Bare git clone (`.bare` directory)
- Proper refspec configuration for fetching all remote branches
- Automatic worktree for the default branch

**`gwt-add <branch>`**: Adds a worktree that:
- Checks if branch exists locally or on remote
- Fetches and tracks existing branches
- Creates new branches when they don't exist
- Sanitizes folder names (replaces `/` and `\` with `_`)

## Test plan

- [x] Run `git-init-worktree` with a test repository
- [x] Verify `gwt-add` works for existing remote branches
- [x] Verify `gwt-add` creates new branches correctly
- [x] Source zsh environment and confirm helpers load without errors